### PR TITLE
Add ipfs urls for 1.1.2

### DIFF
--- a/releases/kovan/1.1.2/index.html
+++ b/releases/kovan/1.1.2/index.html
@@ -10,6 +10,7 @@
 
 			<ul>
 				<li><a href="/releases/kovan/1.1.2/contracts.json">Contract addresses</a></li>
+				<li><a href="https://ipfs.io/ipfs/QmTyr71fGPYoRtpRUpdXJvGKDe3K3QFYWf44sD9qEy4r4c">Contract addresses (IPFS hosted)</a></li>
 				<li><a href="/releases/kovan/1.1.2/abi/index.html">ABIs</a></li>
 			</ul>
 			<p>&nbsp;</p>

--- a/releases/mainnet/1.1.2/index.html
+++ b/releases/mainnet/1.1.2/index.html
@@ -10,6 +10,7 @@
 
 			<ul>
 				<li><a href="/releases/mainnet/1.1.2/contracts.json">Contract addresses</a></li>
+				<li><a href="https://ipfs.io/ipfs/QmbZSsrgKx27V6AQQze5Q2RE7aCTgjvAMG6FJDH3xEaQk7">Contract addresses (IPFS hosted)</a></li>
 				<li><a href="/releases/mainnet/1.1.2/abi/index.html">ABIs</a></li>
 				<li>Links to GitHub repositories</li>
 					<ul>


### PR DESCRIPTION
Add IPFS urls for 1.1.2 releases on mainnet and kovan