### PR TITLE
Update mainnet active links to 1.9.9

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,12 +2,12 @@
   "redirects": [
     {
       "source": "/releases/mainnet/active/contracts.json",
-      "destination": "/releases/mainnet/1.9.8/contracts.json",
+      "destination": "/releases/mainnet/1.9.9/contracts.json",
       "permanent": false
     },
     {
       "source": "/releases/mainnet/active/",
-      "destination": "/releases/mainnet/1.9.8/index.html",
+      "destination": "/releases/mainnet/1.9.9/index.html",
       "permanent": false
     },
     {


### PR DESCRIPTION
Merge only AFTER [the spell](https://vote.makerdao.com/executive/template-executive-vote-aave-d3m-onboarding-and-core-unit-budget-transfers-october-29-2021?network=mainnet#proposal-detail) has been cast.