### PR TITLE
deprecate rinkeby, ropsten, kovan

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 			</tr>
 			<tr>
 				<td><a href="https://oasis.app/">Oasis Borrow and Save</a></td>
-				<td><a href="https://oasis.app/borrow/?network=kovan">Oasis Borrow and Save (linked to Kovan network)</a></td>
+				<td><a href="https://oasis.app/borrow/?network=goerli">Oasis Borrow and Save (linked to Goerli network)</a></td>
 			</tr>
 		</table>
 
@@ -38,15 +38,11 @@
 				<th width="20%" bgcolor="#F4B731" align="center">Main Ethereum network</th>
 				<th width="20%" align="center">Goerli test network</th>
 				<th width="20%" align="center">Kovan test network</th>
-				<th width="20%" align="center">Rinkeby test network</th>
-				<th width="20%" align="center">Ropsten test network</th>
 			</tr>
 			<tr>
 				<td><a href="/releases/mainnet/active/contracts.json">Permanent link to the <b>active Mainnet contracts</b></a><br><a href="/releases/mainnet/active/">Permanent link to the <b>active Mainnet release page</b></a></td>
 				<td><a href="/releases/goerli/active/contracts.json">Permanent link to the <b>active Goerli contracts</b></a><br><a href="/releases/goerli/active/">Permanent link to the <b>active Goerli release page</b></a></td>
-				<td><a href="/releases/kovan/active/contracts.json">Permanent link to the <b>active Kovan contracts</b></a><br><a href="/releases/kovan/active/">Permanent link to the <b>active Kovan release page</b></a></td>
-				<td></td>
-				<td></td>
+				<td>The Kovan MCD deployment was deprecated in August, 2021.</td>
 			</tr>
 			<tr style='font-family: Droid Sans Mono; font-size:80%' align="left" valign="top">
 				<td>
@@ -172,20 +168,6 @@
 						<li><a href="/releases/kovan/0.2.2/index.html">Release 0.2.2</a> (Friday, 2019-03-22)</li>
 						<li><a href="/releases/kovan/0.2.1/index.html">Release 0.2.1</a> (Friday, 2019-03-08)</li>
 				    </ul>
-				</td>
-				<td>
-					<ul>
-						<li><a href="/releases/rinkeby/1.0.4/index.html">Release 1.0.4</a> (Monday, 2020-04-13)</li>
-						<li><a href="/releases/rinkeby/1.0.2/index.html">Release 1.0.2</a> (Monday, 2020-01-17)</li>
-						<li><a href="/releases/rinkeby/0.2.14/index.html">Release 0.2.14</a> (Friday, 2019-10-11)</li>
-					</ul>
-				</td>
-				<td>
-					<ul>
-						<li><a href="/releases/ropsten/1.0.4/index.html">Release 1.0.4</a> (Tuesday, 2020-04-14)</li>
-						<li><a href="/releases/ropsten/1.0.2/index.html">Release 1.0.2</a> (Monday, 2020-01-17)</li>
-						<li><a href="/releases/ropsten/0.2.14/index.html">Release 0.2.14</a> (Wednesday, 2019-10-23)</li>
-					</ul>
 				</td>
 			</tr>
 		</table>


### PR DESCRIPTION
* Remove rinkeby and ropsten from index
* Add deprecation notice to kovan
* Update oasis link from kovan to goerli
* Rinkeby and Ropsten historical data has been preserved for archival purposes.

See [forum post](https://forum.makerdao.com/t/multiple-testnet-deprecation/12216) for details.