### PR TITLE
Deprecation notice

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
         <div style="border: solid red; text-align: center">
           This site will stop receiving updates on May 1st, 2022.<br/>
           Please use <a href="https://chainlog.makerdao.com">chainlog.makerdao.com</a>.<br/>
-          See <a href="https://forum.makerdao.com/t/chainlog-improving-how-we-keep-track-of-our-deployed-contracts/11834">this forum post</a> for more information.
+          See <a href="https://forum.makerdao.com/t/chainlog-improving-how-we-keep-track-of-our-deployed-contracts/11834">this forum post</a> for more information and to provide feedback on the change.
         </div>
 		<h1>
 			<center>MakerDAO Multi-Collateral DAI Public Releases Page</center>

--- a/index.html
+++ b/index.html
@@ -5,9 +5,10 @@
 	</head>
 
 	<body>
-        <div style="border: solid DarkSeaGreen; text-align: center">
-            A new version of this site is available at <a href="https://chainlog.makerdao.com">chainlog.makerdao.com</a>.<br/>
-            See <a href="https://forum.makerdao.com/t/chainlog-improving-how-we-keep-track-of-our-deployed-contracts/11834">this forum post</a> for more info and to provide feedback.
+        <div style="border: solid red; text-align: center">
+          This site will stop receiving updates on May 1st, 2022.<br/>
+          Please use <a href="https://chainlog.makerdao.com">chainlog.makerdao.com</a>.<br/>
+          See <a href="https://forum.makerdao.com/t/chainlog-improving-how-we-keep-track-of-our-deployed-contracts/11834">this forum post</a> for more information.
         </div>
 		<h1>
 			<center>MakerDAO Multi-Collateral DAI Public Releases Page</center>


### PR DESCRIPTION
Now that the new chainlog [UI](https://chainlog.makerdao.com) and [API](https://chainlog.makerdao.com/api.html) are ready, I am proposing May 1st as the day when `mcd-changelog` will stop receiving updates.